### PR TITLE
Fixed: on-screen map and author info didn't scale up as resolution we…

### DIFF
--- a/pk3/zscript/hpack/events/mapcallout.zs
+++ b/pk3/zscript/hpack/events/mapcallout.zs
@@ -90,9 +90,9 @@ class HPMapCalloutEventHandler : EventHandler
 	 */
 	ui void DrawMapCallout(HPMapCallout callout)
 	{
-		int nameWidth   = bigfont.StringWidth(callout.name) * CleanXFac_1;
-		int nameHeight  = bigfont.GetHeight() * CleanYFac_1;
-		int authorWidth = smallfont.StringWidth(callout.author) * CleanXFac_1;
+		int nameWidth   = bigfont.StringWidth(callout.name) * CleanXFac;
+		int nameHeight  = bigfont.GetHeight() * CleanYFac;
+		int authorWidth = smallfont.StringWidth(callout.author) * CleanXFac;
 
 		int xpos = Screen.GetWidth()  * callout.pos.x;
 		int ypos = Screen.GetHeight() * callout.pos.y;
@@ -101,7 +101,7 @@ class HPMapCalloutEventHandler : EventHandler
 		float endfade   = clamp(double(callout.endTime - level.totaltime  ) / (HP_MAP_CALLOUT_FADE_OUT_SECONDS * TICRATE), 0.0, 1.0);
 		float alpha     = min(startfade, endfade);
 
-		Screen.DrawText(bigfont  , Font.CR_RED  , (xpos - (nameWidth   / 2) ), ypos             , callout.name  , DTA_CleanNoMove_1, true, DTA_Alpha, alpha);
-		Screen.DrawText(smallfont, Font.CR_WHITE, (xpos - (authorWidth / 2) ), ypos + nameHeight, callout.author, DTA_CleanNoMove_1, true, DTA_Alpha, alpha);
+		Screen.DrawText(bigfont  , Font.CR_RED  , (xpos - (nameWidth   / 2) ), ypos             , callout.name  , DTA_CleanNoMove, true, DTA_Alpha, alpha);
+		Screen.DrawText(smallfont, Font.CR_WHITE, (xpos - (authorWidth / 2) ), ypos + nameHeight, callout.author, DTA_CleanNoMove, true, DTA_Alpha, alpha);
 	}
 }


### PR DESCRIPTION
This is how it looks without the change I'm introducing in this PR (this is on 1366x768, my PC's native resolution):
![before](https://user-images.githubusercontent.com/4287687/175845578-8bc63161-e74d-4062-98cd-ac52dfb784aa.png)

And this is how it looks with the change:
![after](https://user-images.githubusercontent.com/4287687/175845714-4e56ddae-56b4-46a6-a0de-e316a5be3572.png)

Now the text is no longer tiny, and is actually readable!

While I could commit the change myself, I opted to make a PR for the purpose of review.